### PR TITLE
Improve CLI behavior on faulty config/settings.yaml

### DIFF
--- a/src/main/java/cloudgene/mapred/cli/BaseTool.java
+++ b/src/main/java/cloudgene/mapred/cli/BaseTool.java
@@ -26,7 +26,9 @@ public abstract class BaseTool extends Tool {
 			settings = Settings.load();
 			repository = settings.getApplicationRepository();
 		} catch (Exception e) {
-			printError(e.getMessage());
+			printError("Failed to load settings; exiting application. Reason:");
+			e.printStackTrace();
+			System.exit(1);
 		}
 	}
 


### PR DESCRIPTION
Previously, BaseTool::init() swallowed settings loading issues, and the application failed due to downstream errors. This change ensures the error is reported clearly and immediately, and the application quits instead of continuing in a bad state.