### PR TITLE
Fix S3 Workspace Bug

### DIFF
--- a/src/main/java/cloudgene/mapred/apps/ApplicationRepository.java
+++ b/src/main/java/cloudgene/mapred/apps/ApplicationRepository.java
@@ -87,8 +87,8 @@ public class ApplicationRepository {
 			indexApps.put(app.getId(), app);
 
 		}
-		
-		Collections.sort(apps);		
+
+		Collections.sort(apps);
 		log.info("Loaded " + apps.size() + " applications.");
 	}
 
@@ -332,7 +332,8 @@ public class ApplicationRepository {
 		FileUtil.deleteDirectory(appPath);
 		FileUtil.createDirectory(appPath);
 
-		String baseKey = S3Util.getKey(url);
+		S3Util.UrlParts urlParts = S3Util.getParts(url);
+		String baseKey = urlParts.key();
 
 		ObjectListing listing = S3Util.listObjects(url);
 

--- a/src/main/java/cloudgene/mapred/cli/BaseTool.java
+++ b/src/main/java/cloudgene/mapred/cli/BaseTool.java
@@ -26,7 +26,9 @@ public abstract class BaseTool extends Tool {
 			settings = Settings.load();
 			repository = settings.getApplicationRepository();
 		} catch (Exception e) {
-			printError(e.getMessage());
+			printError("Failed to load settings; exiting application. Reason:");
+			e.printStackTrace();
+			System.exit(1);
 		}
 	}
 

--- a/src/main/java/cloudgene/mapred/plugins/nextflow/NextflowProcessRenderer.java
+++ b/src/main/java/cloudgene/mapred/plugins/nextflow/NextflowProcessRenderer.java
@@ -2,7 +2,7 @@ package cloudgene.mapred.plugins.nextflow;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
Fix bug in `S3Workspace.downloadLog()`; refactor S3Util S3 URL part retrieval for resilience.

Prior to this change, `S3Workspace.downloadLog()` passes a relative path to its `download()` function, which expects an S3 URL. This causes the `S3Util` methods `getBucket()` and `getKey()` (which have duplicated logic) to return `null` without erroring, leading to an exception being thrown when we call the AWS S3 API (still inside `S3Workspace.download()`).

This change provides two fixes, one for the immediate bug and one for the underlying S3 URL processing issue:
* `S3Workspace.downloadLog()` now passes a full S3 URL to `S3Workspace.download()`, fixing the bug.
* `S3Util.getBucket()` and `S3Util.getKey()` have been replaced with `S3Util.getParts()`, which returns an immutable record with two fields: `bucket()` and `key()`. `getParts()` throws an `IllegalArgumentException` if the input URL does not conform to the expected format:` s3://<bucket>/<key>`. Because of the new error-throwing behavior, this type of issue should be easier to diagnose in the future.