### PR TITLE
Add 'skipWorkspaceCleanup' setting

### DIFF
--- a/src/main/java/cloudgene/mapred/jobs/CloudgeneJob.java
+++ b/src/main/java/cloudgene/mapred/jobs/CloudgeneJob.java
@@ -221,8 +221,8 @@ public class CloudgeneJob extends AbstractJob {
 	public boolean cleanUp() {
 
 		Settings settings = getSettings();
-		boolean skipCleanup = settings.getSkipWorkspaceCleanup();
-		if (skipCleanup) {
+		boolean shouldCleanUp = settings.getWorkspaceCleanup();
+		if (!shouldCleanUp) {
 			log.info("[Job {}] Skipping cleanup.", getId());
 			return false;
 		}

--- a/src/main/java/cloudgene/mapred/jobs/CloudgeneJob.java
+++ b/src/main/java/cloudgene/mapred/jobs/CloudgeneJob.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.*;
 
 import cloudgene.mapred.util.GlobUtil;
+import cloudgene.mapred.util.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -218,6 +219,13 @@ public class CloudgeneJob extends AbstractJob {
 
 	@Override
 	public boolean cleanUp() {
+
+		Settings settings = getSettings();
+		boolean skipCleanup = settings.getSkipWorkspaceCleanup();
+		if (skipCleanup) {
+			log.info("[Job {}] Skipping cleanup.", getId());
+			return false;
+		}
 
 		log.info("[Job {}] Cleaning up...", getId());
 

--- a/src/main/java/cloudgene/mapred/util/Settings.java
+++ b/src/main/java/cloudgene/mapred/util/Settings.java
@@ -86,7 +86,7 @@ public class Settings {
 
 	private String port = "8082";
 
-	private boolean skipWorkspaceCleanup = false;
+	private boolean workspaceCleanup = true;
 
 	private List<String> counters = new Vector<String>();
 
@@ -429,9 +429,9 @@ public class Settings {
 		return port;
 	}
 
-	public void setSkipWorkspaceCleanup(boolean skipWorkspaceCleanup) { this.skipWorkspaceCleanup = skipWorkspaceCleanup; }
+	public void setWorkspaceCleanup(boolean workspaceCleanup) { this.workspaceCleanup = workspaceCleanup; }
 
-	public boolean getSkipWorkspaceCleanup() { return skipWorkspaceCleanup; }
+	public boolean getWorkspaceCleanup() { return workspaceCleanup; }
 
 	public void setShowLogs(boolean showLogs) {
 		this.showLogs = showLogs;

--- a/src/main/java/cloudgene/mapred/util/Settings.java
+++ b/src/main/java/cloudgene/mapred/util/Settings.java
@@ -86,6 +86,8 @@ public class Settings {
 
 	private String port = "8082";
 
+	private boolean skipWorkspaceCleanup = false;
+
 	private List<String> counters = new Vector<String>();
 
 	public static final String DEFAULT_SECURITY_KEY = "default-key-change-me-immediately";
@@ -426,6 +428,10 @@ public class Settings {
 	public String getPort() {
 		return port;
 	}
+
+	public void setSkipWorkspaceCleanup(boolean skipWorkspaceCleanup) { this.skipWorkspaceCleanup = skipWorkspaceCleanup; }
+
+	public boolean getSkipWorkspaceCleanup() { return skipWorkspaceCleanup; }
 
 	public void setShowLogs(boolean showLogs) {
 		this.showLogs = showLogs;


### PR DESCRIPTION
This change adds a new configuration option `Settings.skipWorkspaceCleanup`, which is used in `Job.cleanUp()` to skip any cleanup work. It defaults to `false`, preserving normal behavior.

Setting the flag to `true` keeps Cloudgene from destroying a job's `temp/` folder when the job ends (including failures and cancellations). Since this folder includes all NextFlow artifacts, such as step commands and logs, activating the setting allows for a better debugging experience, and should allow job restarts.