### PR TITLE
RELEASE.md docs: fix outdated reference to cloudgene/mapred/Main.java

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ Update version according Sematic Versioning:
 
 We track our current version in
 - `pom.xml`
-- `src/main/java/cloudgene/mapred/Main.java`
+- `src/main/java/cloudgene/mapred/server/Application.java`
 - `src/main/html/webapp/package.json`.
 
 Set the new version without the `v` prefix.


### PR DESCRIPTION
In `RELEASE.md` there is a list of all files that contain a hardcoded string for the current version of the app. The list is out of date, and requires a substitution:

`cloudgene/mapred/Main.java` -> `cloudgene/mapred/server/Application.java`

This change gets the list up to date.