### PR TITLE
Mitigate tmp/ disk leakage

### DIFF
--- a/src/main/java/cloudgene/mapred/jobs/JobParameterParser.java
+++ b/src/main/java/cloudgene/mapred/jobs/JobParameterParser.java
@@ -96,6 +96,8 @@ public class JobParameterParser {
                 if (input.getWriteFile() != null && !input.getWriteFile().trim().isEmpty()) {
 
                     File file = Files.createTempFile("upload_", input.getWriteFile()).toFile();
+                    file.deleteOnExit();
+
                     try {
                         FileUtil.writeStringBufferToFile(file.getAbsolutePath(), new StringBuffer(cleanedValue));
                         String target = workspace.uploadInput(key, file);

--- a/src/main/java/cloudgene/mapred/server/controller/JobController.java
+++ b/src/main/java/cloudgene/mapred/server/controller/JobController.java
@@ -90,7 +90,9 @@ public class JobController {
 		String userAgent = request.getHeaders().get(HttpHeaders.USER_AGENT);
 
 		long start = System.currentTimeMillis();
+
 		File folder = application.getSettings().getTempFolder("upload_");
+		folder.deleteOnExit();
 
 		log.debug("Start submit process and parse multipart body. Folder for request: " + folder.getAbsolutePath());
 


### PR DESCRIPTION
When Cloudgene uses an S3 workspace, input files are not uploaded directly to S3. Instead, they are staged in the server's disk at the `tmp/` folder (local to `cloudgene`), and then uploaded. Under certain circumstances, Cloudgene can fail to delete the files, and they stay indefinitely in `tmp/`, clogging the disk and potentially leading to system failure.

The current solution we have implemented in the TOPMed Imputation Server is a `systemd` timer that periodically deletes old folders in `tmp/`. As far as I'm aware, there is no good solution within the Cloudgene codebase, as anything here would break if the Java process ends suddenly.

This change reduces the risk of leakage, though it only applies when the JVM is allowed to do a full shutdown.